### PR TITLE
Added support for passing in the private key as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjkl=
 
 session = Session()
 session.auth = IntersightAuth(
-    api_key_id="61e876697564612d33c0b91b/61e876697564612d33c0b920/629933367564612d31dd11f3", 
+    api_key_id="XYZ/XYZ/XYZ", 
     secret_key_string=my_secret_key
     )
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This module provides an authentication helper for requests to make it easy to ma
 pip install intersight-auth
 ```
 
-## Example
+## Example using a file for the secret key
 
-```
+``` Python
 import sys
 
 from intersight_auth import IntersightAuth
 from requests import Session
 
 session = Session()
-session.auth = IntersightAuth("key.pem", "XYZ/XYZ/XYZ")
+session.auth = IntersightAuth("XYZ/XYZ/XYZ", "key.pem")
 
 response = session.get("https://intersight.com/api/v1/ntp/Policies")
 
@@ -29,3 +29,54 @@ for policy in response.json()["Results"]:
     print(f"{policy['Name']}")
 ```
 
+## Example using a multiline (a.k.a. heredoc) string for the secret key
+
+The secret key must still be in PEM format even if it's a string instead of a file.
+
+``` Python
+my_secret_key='''
+-----BEGIN RSA PRIVATE KEY-----
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjklmnopqrstuvwxy
+ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/abcdefghizjkl=
+-----END RSA PRIVATE KEY-----
+'''
+
+session = Session()
+session.auth = IntersightAuth(
+    api_key_id="61e876697564612d33c0b91b/61e876697564612d33c0b920/629933367564612d31dd11f3", 
+    secret_key_string=my_secret_key
+    )
+
+response = session.get("https://intersight.com/api/v1/ntp/Policies")
+
+if not response.ok:
+    print(f"Error: {response.status_code} {response.reason}")
+    sys.exit(1)
+
+for policy in response.json()["Results"]:
+    print(f"{policy['Name']}")
+```


### PR DESCRIPTION
The key can now be passed into the class either as a file or as a string.  Unfortunately, I did have to change the order of arguments on the constructor since secret_key_filename was first and it needed to become optional.  This seemed to be the most straightforward approach to me, but I'm open to feedback. 

Resolves #1 