### PR TITLE
Fix _get_sha256_digest if data is bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,20 @@ jobs:
           source .venv/bin/activate
           pytest -v
           python examples/ntp.py
+      - name: Run timeseries tests with v2 keys
+        env:
+          IS_KEY_ID: ${{ secrets.IS_KEY_ID_V2 }}
+          IS_KEY: ${{ secrets.IS_KEY_V2 }}
+        run: |
+          source .venv/bin/activate
+          pytest -v
+          python examples/timeseries.py
+      - name: Run timeseries tests with v3 keys
+        env:
+          IS_KEY_ID: ${{ secrets.IS_KEY_ID_V3 }}
+          IS_KEY: ${{ secrets.IS_KEY_V3 }}
+        run: |
+          source .venv/bin/activate
+          pytest -v
+          python examples/timeseries.py
+      

--- a/examples/timeseries.py
+++ b/examples/timeseries.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import json
+import os
+import random
+import string
+import sys
+from datetime import datetime, timedelta
+
+from intersight_auth import IntersightAuth
+from requests import Session
+
+base_url = "https://intersight.com/api/v1"
+
+key_id = os.environ["IS_KEY_ID"]
+secret_key = os.environ["IS_KEY"]
+
+session = Session()
+session.auth = IntersightAuth(key_id, secret_key_string=secret_key)
+
+
+now = f"{datetime.now().isoformat()[:-6].rstrip('0')}000Z"
+correctresponse = (
+    f"{(datetime.now() - timedelta(days=1)).isoformat()[:-6].rstrip('0')}000Z"
+)
+
+query = json.loads(
+    """
+{
+    "queryType": "timeseries",
+    "dataSource": "hx",
+    "intervals": [
+        "P1D/%s"
+    ],
+    "granularity":  "all"
+}
+"""
+    % (now)
+)
+
+print("Getting timeseries data ...")
+response = session.post(url=base_url + "/telemetry/TimeSeries", json=query)
+
+if not response.ok:
+    print(f"Error: {response.status_code} {response.reason}")
+    print(response.text)
+    sys.exit(1)
+
+thejson = response.json()
+assert response.json()[0]["timestamp"] == correctresponse
+print("Successfully retrieved timeseries")

--- a/intersight_auth/intersight_auth.py
+++ b/intersight_auth/intersight_auth.py
@@ -22,7 +22,7 @@ def _get_sha256_digest(data):
     hasher = hashes.Hash(hashes.SHA256(), default_backend())
 
     if data is not None:
-        if type(data) == bytes:  
+        if type(data) == bytes:
             hasher.update(data)
         else:
             hasher.update(data.encode())

--- a/intersight_auth/intersight_auth.py
+++ b/intersight_auth/intersight_auth.py
@@ -21,7 +21,10 @@ def _get_sha256_digest(data):
     hasher = hashes.Hash(hashes.SHA256(), default_backend())
 
     if data is not None:
-        hasher.update(data.encode())
+        if type(data) == bytes:  
+            hasher.update(data)
+        else:
+            hasher.update(data.encode())
 
     return hasher.finalize()
 


### PR DESCRIPTION
In attempting to do a JSON post to the TimeSeries endpoint where the variable `QUERY` is a dict with the time series query parameters... 

```PYTHON
RESPONSE = requests.post(
    url='https://intersight.com/api/v1/telemetry/TimeSeries',
    json=QUERY,
    auth=AUTH
)
```

I encountered the following exception...

`'bytes' object has no attribute 'encode'`

This was due to the fact that the _get_sha256_digest method was attempting to encode a variable that was already in bytes.